### PR TITLE
Fix Discord OAuth issues

### DIFF
--- a/src/lib/discord/api.ts
+++ b/src/lib/discord/api.ts
@@ -15,11 +15,11 @@ function makeGetGuildMemberURL(r: GetGuildMemberRequest, apiURL = API_URL): stri
 export async function getGuildMember(r: GetGuildMemberRequest): Promise<APIGuildMember> {
 	const response = await fetch(makeGetGuildMemberURL(r), {
 		headers: {
-			Authorization: `Bearer ${r.botToken}`
+			Authorization: `Bot ${r.botToken}`
 		}
 	});
 	if (!response.ok) {
-		throw new Error(`Failed to get guild member: ${response.statusText}`);
+		throw new Error(`Failed to get guild member: ${response.status} ${response.statusText}`);
 	}
 
 	return await response.json();
@@ -49,7 +49,7 @@ export async function createMessage(r: CreateMessageRequest): Promise<APIGuildMe
 	const response = await fetch(makeCreateMessageURL(r), {
 		method: 'POST',
 		headers: {
-			Authorization: `Bearer ${r.botToken}`
+			Authorization: `Bot ${r.botToken}`
 		},
 		body: JSON.stringify(r.body)
 	});

--- a/src/routes/discord_oauth2/+server.ts
+++ b/src/routes/discord_oauth2/+server.ts
@@ -34,7 +34,8 @@ export const GET: RequestHandler = async ({ url, locals }) => {
 		return makeRedirect(
 			makeOAuth2URL({
 				clientID: DISCORD_CLIENT_ID,
-				redirectURI: DISCORD_REDIRECT_URI
+				redirectURI: DISCORD_REDIRECT_URI,
+				state: JSON.stringify({ destination: state.destination })
 			})
 		);
 	}

--- a/src/routes/forms/+layout.server.ts
+++ b/src/routes/forms/+layout.server.ts
@@ -17,6 +17,6 @@ import { makeOAuth2URL } from '$lib/oauth2';
 
 export const load: LayoutServerLoad = async ({ locals, url }) => {
 	if (!locals.user) {
-		redirect(303, makeOAuth2URL(url.toString()));
+		throw redirect(303, makeOAuth2URL(url.toString()));
 	}
 };


### PR DESCRIPTION
# Discord OAuth Issues
Issues include a 401 error when fetching GuildMember, improper access control for unauthenticated users, and ensuring users are redirected back to their original destination after OAuth authentication.

## Changes

### **Fix 401 Error when Fetching `GuildMember`**
- Resolved an issue where a request to fetch `GuildMember` was returning a `401 Unauthorized` error.
- Updated authentication headers to ensure the bot has proper authorization when making API requests.

### **Improve Authentication & Authorization**
- Prevented users from accessing pages without proper authentication and authorization.
- Updated `+Layout.svelte` in the `forms` route to properly handle redirects instead of just creating them without execution.
- Fixing the previous issue with fetching `GuildMember` now enables a specified role to be required on a Server to be able to login.

### Fix Incorrect login Redirect
- Resolved an issue where users were always redirected to the homepage after logging in instead of the original URL they attempted to access.
- Updated makeOAuth2URL to include state="", ensuring the original URL is saved throughout the OAuth process.